### PR TITLE
Fix positioning on first draw of arrow theme

### DIFF
--- a/css/tether-theme-arrows-dark.css
+++ b/css/tether-theme-arrows-dark.css
@@ -34,79 +34,57 @@
       border-color: transparent;
       border-width: 16px;
       border-style: solid; }
-  .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-center .tether-content {
-    margin-bottom: 16px; }
-    .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-center .tether-content:before {
-      top: 100%;
-      left: 50%;
-      margin-left: -16px;
-      border-top-color: black; }
-  .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-center .tether-content {
-    margin-top: 16px; }
-    .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-center .tether-content:before {
-      bottom: 100%;
-      left: 50%;
-      margin-left: -16px;
-      border-bottom-color: black; }
-  .tether-element.tether-theme-arrows-dark.tether-element-attached-right.tether-element-attached-middle .tether-content {
-    margin-right: 16px; }
-    .tether-element.tether-theme-arrows-dark.tether-element-attached-right.tether-element-attached-middle .tether-content:before {
-      left: 100%;
-      top: 50%;
-      margin-top: -16px;
-      border-left-color: black; }
-  .tether-element.tether-theme-arrows-dark.tether-element-attached-left.tether-element-attached-middle .tether-content {
-    margin-left: 16px; }
-    .tether-element.tether-theme-arrows-dark.tether-element-attached-left.tether-element-attached-middle .tether-content:before {
-      right: 100%;
-      top: 50%;
-      margin-top: -16px;
-      border-right-color: black; }
-  .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-left.tether-target-attached-bottom .tether-content {
-    margin-top: 16px; }
-    .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-left.tether-target-attached-bottom .tether-content:before {
-      bottom: 100%;
-      left: 16px;
-      border-bottom-color: black; }
-  .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-right.tether-target-attached-bottom .tether-content {
-    margin-top: 16px; }
-    .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-right.tether-target-attached-bottom .tether-content:before {
-      bottom: 100%;
-      right: 16px;
-      border-bottom-color: black; }
-  .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-top .tether-content {
-    margin-bottom: 16px; }
-    .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-top .tether-content:before {
-      top: 100%;
-      left: 16px;
-      border-top-color: black; }
-  .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-top .tether-content {
-    margin-bottom: 16px; }
-    .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-top .tether-content:before {
-      top: 100%;
-      right: 16px;
-      border-top-color: black; }
-  .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-right.tether-target-attached-left .tether-content {
-    margin-right: 16px; }
-    .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-right.tether-target-attached-left .tether-content:before {
-      top: 16px;
-      left: 100%;
-      border-left-color: black; }
-  .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-left.tether-target-attached-right .tether-content {
-    margin-left: 16px; }
-    .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-left.tether-target-attached-right .tether-content:before {
-      top: 16px;
-      right: 100%;
-      border-right-color: black; }
-  .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-left .tether-content {
-    margin-right: 16px; }
-    .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-left .tether-content:before {
-      bottom: 16px;
-      left: 100%;
-      border-left-color: black; }
-  .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-right .tether-content {
-    margin-left: 16px; }
-    .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-right .tether-content:before {
-      bottom: 16px;
-      right: 100%;
-      border-right-color: black; }
+  .tether-element.tether-theme-arrows-dark .tether-content {
+    margin: 16px; }
+  .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-center .tether-content:before {
+    top: 100%;
+    left: 50%;
+    margin-left: -16px;
+    border-top-color: black; }
+  .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-center .tether-content:before {
+    bottom: 100%;
+    left: 50%;
+    margin-left: -16px;
+    border-bottom-color: black; }
+  .tether-element.tether-theme-arrows-dark.tether-element-attached-right.tether-element-attached-middle .tether-content:before {
+    left: 100%;
+    top: 50%;
+    margin-top: -16px;
+    border-left-color: black; }
+  .tether-element.tether-theme-arrows-dark.tether-element-attached-left.tether-element-attached-middle .tether-content:before {
+    right: 100%;
+    top: 50%;
+    margin-top: -16px;
+    border-right-color: black; }
+  .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-left.tether-target-attached-bottom .tether-content:before {
+    bottom: 100%;
+    left: 16px;
+    border-bottom-color: black; }
+  .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-right.tether-target-attached-bottom .tether-content:before {
+    bottom: 100%;
+    right: 16px;
+    border-bottom-color: black; }
+  .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-top .tether-content:before {
+    top: 100%;
+    left: 16px;
+    border-top-color: black; }
+  .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-top .tether-content:before {
+    top: 100%;
+    right: 16px;
+    border-top-color: black; }
+  .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-right.tether-target-attached-left .tether-content:before {
+    top: 16px;
+    left: 100%;
+    border-left-color: black; }
+  .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-left.tether-target-attached-right .tether-content:before {
+    top: 16px;
+    right: 100%;
+    border-right-color: black; }
+  .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-left .tether-content:before {
+    bottom: 16px;
+    left: 100%;
+    border-left-color: black; }
+  .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-right .tether-content:before {
+    bottom: 16px;
+    right: 100%;
+    border-right-color: black; }

--- a/css/tether-theme-arrows.css
+++ b/css/tether-theme-arrows.css
@@ -36,79 +36,57 @@
       border-color: transparent;
       border-width: 16px;
       border-style: solid; }
-  .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-center .tether-content {
-    margin-bottom: 16px; }
-    .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-center .tether-content:before {
-      top: 100%;
-      left: 50%;
-      margin-left: -16px;
-      border-top-color: white; }
-  .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-center .tether-content {
-    margin-top: 16px; }
-    .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-center .tether-content:before {
-      bottom: 100%;
-      left: 50%;
-      margin-left: -16px;
-      border-bottom-color: white; }
-  .tether-element.tether-theme-arrows.tether-element-attached-right.tether-element-attached-middle .tether-content {
-    margin-right: 16px; }
-    .tether-element.tether-theme-arrows.tether-element-attached-right.tether-element-attached-middle .tether-content:before {
-      left: 100%;
-      top: 50%;
-      margin-top: -16px;
-      border-left-color: white; }
-  .tether-element.tether-theme-arrows.tether-element-attached-left.tether-element-attached-middle .tether-content {
-    margin-left: 16px; }
-    .tether-element.tether-theme-arrows.tether-element-attached-left.tether-element-attached-middle .tether-content:before {
-      right: 100%;
-      top: 50%;
-      margin-top: -16px;
-      border-right-color: white; }
-  .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-left.tether-target-attached-bottom .tether-content {
-    margin-top: 16px; }
-    .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-left.tether-target-attached-bottom .tether-content:before {
-      bottom: 100%;
-      left: 16px;
-      border-bottom-color: white; }
-  .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-right.tether-target-attached-bottom .tether-content {
-    margin-top: 16px; }
-    .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-right.tether-target-attached-bottom .tether-content:before {
-      bottom: 100%;
-      right: 16px;
-      border-bottom-color: white; }
-  .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-top .tether-content {
-    margin-bottom: 16px; }
-    .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-top .tether-content:before {
-      top: 100%;
-      left: 16px;
-      border-top-color: white; }
-  .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-top .tether-content {
-    margin-bottom: 16px; }
-    .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-top .tether-content:before {
-      top: 100%;
-      right: 16px;
-      border-top-color: white; }
-  .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-right.tether-target-attached-left .tether-content {
-    margin-right: 16px; }
-    .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-right.tether-target-attached-left .tether-content:before {
-      top: 16px;
-      left: 100%;
-      border-left-color: white; }
-  .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-left.tether-target-attached-right .tether-content {
-    margin-left: 16px; }
-    .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-left.tether-target-attached-right .tether-content:before {
-      top: 16px;
-      right: 100%;
-      border-right-color: white; }
-  .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-left .tether-content {
-    margin-right: 16px; }
-    .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-left .tether-content:before {
-      bottom: 16px;
-      left: 100%;
-      border-left-color: white; }
-  .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-right .tether-content {
-    margin-left: 16px; }
-    .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-right .tether-content:before {
-      bottom: 16px;
-      right: 100%;
-      border-right-color: white; }
+  .tether-element.tether-theme-arrows .tether-content {
+    margin: 16px; }
+  .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-center .tether-content:before {
+    top: 100%;
+    left: 50%;
+    margin-left: -16px;
+    border-top-color: white; }
+  .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-center .tether-content:before {
+    bottom: 100%;
+    left: 50%;
+    margin-left: -16px;
+    border-bottom-color: white; }
+  .tether-element.tether-theme-arrows.tether-element-attached-right.tether-element-attached-middle .tether-content:before {
+    left: 100%;
+    top: 50%;
+    margin-top: -16px;
+    border-left-color: white; }
+  .tether-element.tether-theme-arrows.tether-element-attached-left.tether-element-attached-middle .tether-content:before {
+    right: 100%;
+    top: 50%;
+    margin-top: -16px;
+    border-right-color: white; }
+  .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-left.tether-target-attached-bottom .tether-content:before {
+    bottom: 100%;
+    left: 16px;
+    border-bottom-color: white; }
+  .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-right.tether-target-attached-bottom .tether-content:before {
+    bottom: 100%;
+    right: 16px;
+    border-bottom-color: white; }
+  .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-top .tether-content:before {
+    top: 100%;
+    left: 16px;
+    border-top-color: white; }
+  .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-top .tether-content:before {
+    top: 100%;
+    right: 16px;
+    border-top-color: white; }
+  .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-right.tether-target-attached-left .tether-content:before {
+    top: 16px;
+    left: 100%;
+    border-left-color: white; }
+  .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-left.tether-target-attached-right .tether-content:before {
+    top: 16px;
+    right: 100%;
+    border-right-color: white; }
+  .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-left .tether-content:before {
+    bottom: 16px;
+    left: 100%;
+    border-left-color: white; }
+  .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-right .tether-content:before {
+    bottom: 16px;
+    right: 100%;
+    border-right-color: white; }

--- a/sass/helpers/_tether-theme-arrows.sass
+++ b/sass/helpers/_tether-theme-arrows.sass
@@ -31,9 +31,10 @@
 
         // Centers and middles
 
-        &.#{ $themePrefix }-element-attached-bottom.#{ $themePrefix }-element-attached-center .#{ $themePrefix }-content
-            margin-bottom: $arrowSize
+        .#{ $themePrefix }-content
+            margin: $arrowSize
 
+        &.#{ $themePrefix }-element-attached-bottom.#{ $themePrefix }-element-attached-center .#{ $themePrefix }-content
             &:before
                 top: 100%
                 left: 50%
@@ -41,8 +42,6 @@
                 border-top-color: $backgroundColor
 
         &.#{ $themePrefix }-element-attached-top.#{ $themePrefix }-element-attached-center .#{ $themePrefix }-content
-            margin-top: $arrowSize
-
             &:before
                 bottom: 100%
                 left: 50%
@@ -50,8 +49,6 @@
                 border-bottom-color: $backgroundColor
 
         &.#{ $themePrefix }-element-attached-right.#{ $themePrefix }-element-attached-middle .#{ $themePrefix }-content
-            margin-right: $arrowSize
-
             &:before
                 left: 100%
                 top: 50%
@@ -59,8 +56,6 @@
                 border-left-color: $backgroundColor
 
         &.#{ $themePrefix }-element-attached-left.#{ $themePrefix }-element-attached-middle .#{ $themePrefix }-content
-            margin-left: $arrowSize
-
             &:before
                 right: 100%
                 top: 50%
@@ -70,32 +65,24 @@
         // Top and bottom corners
 
         &.#{ $themePrefix }-element-attached-top.#{ $themePrefix }-element-attached-left.#{ $themePrefix }-target-attached-bottom .#{ $themePrefix }-content
-            margin-top: $arrowSize
-
             &:before
                 bottom: 100%
                 left: $arrowSize
                 border-bottom-color: $backgroundColor
 
         &.#{ $themePrefix }-element-attached-top.#{ $themePrefix }-element-attached-right.#{ $themePrefix }-target-attached-bottom .#{ $themePrefix }-content
-            margin-top: $arrowSize
-
             &:before
                 bottom: 100%
                 right: $arrowSize
                 border-bottom-color: $backgroundColor
 
         &.#{ $themePrefix }-element-attached-bottom.#{ $themePrefix }-element-attached-left.#{ $themePrefix }-target-attached-top .#{ $themePrefix }-content
-            margin-bottom: $arrowSize
-
             &:before
                 top: 100%
                 left: $arrowSize
                 border-top-color: $backgroundColor
 
         &.#{ $themePrefix }-element-attached-bottom.#{ $themePrefix }-element-attached-right.#{ $themePrefix }-target-attached-top .#{ $themePrefix }-content
-            margin-bottom: $arrowSize
-
             &:before
                 top: 100%
                 right: $arrowSize
@@ -104,32 +91,24 @@
         // Side corners
 
         &.#{ $themePrefix }-element-attached-top.#{ $themePrefix }-element-attached-right.#{ $themePrefix }-target-attached-left .#{ $themePrefix }-content
-            margin-right: $arrowSize
-
             &:before
                 top: $arrowSize
                 left: 100%
                 border-left-color: $backgroundColor
 
         &.#{ $themePrefix }-element-attached-top.#{ $themePrefix }-element-attached-left.#{ $themePrefix }-target-attached-right .#{ $themePrefix }-content
-            margin-left: $arrowSize
-
             &:before
                 top: $arrowSize
                 right: 100%
                 border-right-color: $backgroundColor
 
         &.#{ $themePrefix }-element-attached-bottom.#{ $themePrefix }-element-attached-right.#{ $themePrefix }-target-attached-left .#{ $themePrefix }-content
-            margin-right: $arrowSize
-
             &:before
                 bottom: $arrowSize
                 left: 100%
                 border-left-color: $backgroundColor
 
         &.#{ $themePrefix }-element-attached-bottom.#{ $themePrefix }-element-attached-left.#{ $themePrefix }-target-attached-right .#{ $themePrefix }-content
-            margin-left: $arrowSize
-
             &:before
                 bottom: $arrowSize
                 right: 100%


### PR DESCRIPTION
@adamschwartz 

This is why the drop elements weren't positioning correctly on the first draw.  You can't base the size of the element on it's attachment classes, as the attachment classes can only be added after we know the size of the element.

This change might have unintended consequences though, in terms of elements flipping `$arrowSize`px before they should, so I leave it for you to review.
