### PR TITLE
Fix tether.js resource url in examples

### DIFF
--- a/examples/content-visible/index.html
+++ b/examples/content-visible/index.html
@@ -49,8 +49,8 @@
         <p>It's setup to align with the center of the visible part of the blue area.</p>
       </div>
     </div>
- 
-    <script src="/tether/tether.js"></script>
+
+    <script src="/js/tether.js"></script>
     <script>
       new Tether({
         element: '.element',

--- a/examples/dolls/index.html
+++ b/examples/dolls/index.html
@@ -1,5 +1,5 @@
 <link rel="stylesheet" href="./dolls.css" />
-<script src="/tether/tether.js"></script>
+<script src="/js/tether.js"></script>
 <script src="./dolls.js"></script>
 <body>
   <div class="scroll">

--- a/examples/element-scroll/index.html
+++ b/examples/element-scroll/index.html
@@ -118,7 +118,7 @@
       crash of the notorious Travancore and Deccan Banking Corporation, whose
       downfall had shaken the East like an earthquake. And he was sixty-five
       years old.</p>
-      
+
       <p>His age sat lightly enough on him; and of his ruin he was not ashamed.
       He had not been alone to believe in the stability of the Banking
       Corporation. Men whose judgment in matters of finance was as expert as
@@ -441,7 +441,7 @@
       }
     </style>
 
-    <script src="/tether/tether.js"></script>
+    <script src="/js/tether.js"></script>
     <script>
       var pointer = document.querySelector('.pointer');
       var scroll = document.querySelector('.scroll');
@@ -473,7 +473,7 @@
         if (!spans) return;
 
         var bar = pointer.getBoundingClientRect();
-        
+
         for (var i=spans.length; i--;){
           var coord = spans[i].getBoundingClientRect();
 

--- a/examples/enable-disable/index.html
+++ b/examples/enable-disable/index.html
@@ -9,7 +9,7 @@
     </head>
     <body>
         <div class="instructions">Click the green target to enable/disable the tethering.</div>
-  
+
         <div class="element"></div>
         <div class="container">
             <div class="pad"></div>
@@ -17,7 +17,7 @@
             <div class="pad"></div>
         </div>
 
-        <script src="/tether/tether.js"></script>
+        <script src="/js/tether.js"></script>
         <script>
             var tether = new Tether({
                 element: '.element',

--- a/examples/out-of-bounds/index.html
+++ b/examples/out-of-bounds/index.html
@@ -14,11 +14,11 @@
     </head>
     <body>
         <div class="instructions">Resize the screen to see the tethered element disappear when it can't fit.</div>
-  
+
         <div class="element"></div>
         <div class="target"></div>
 
-        <script src="/tether/tether.js"></script>
+        <script src="/js/tether.js"></script>
         <script>
             new Tether({
                 element: '.element',

--- a/examples/pin/index.html
+++ b/examples/pin/index.html
@@ -9,11 +9,11 @@
     </head>
     <body>
         <div class="instructions">Resize the screen to see the tethered element stick to the edges of the screen when it's resized.</div>
-  
+
         <div class="element"></div>
         <div class="target"></div>
 
-        <script src="/tether/tether.js"></script>
+        <script src="/js/tether.js"></script>
         <script>
             new Tether({
                 element: '.element',

--- a/examples/scroll/index.html
+++ b/examples/scroll/index.html
@@ -877,7 +877,7 @@
 
       <div class="pointer"></div>
 
-      <script src="/tether/tether.js"></script>
+      <script src="/js/tether.js"></script>
       <script>
         new Tether({
           element: '.pointer',
@@ -912,7 +912,7 @@
 
           if (hideTimeout)
             clearTimeout(hideTimeout);
-  
+
           hideTimeout = setTimeout(function(){
             pointer.classList.remove('show');
           }, 1000);

--- a/examples/simple/index.html
+++ b/examples/simple/index.html
@@ -9,11 +9,11 @@
     </head>
     <body>
         <div class="instructions">Resize the page to see the Tether flip.</div>
-  
+
         <div class="element"></div>
         <div class="target"></div>
 
-        <script src="/tether/tether.js"></script>
+        <script src="/js/tether.js"></script>
         <script>
             new Tether({
                 element: '.element',

--- a/examples/testbed/index.html
+++ b/examples/testbed/index.html
@@ -19,7 +19,7 @@
             <div class="pad"></div>
         </div>
 
-        <script src="/tether/tether.js"></script>
+        <script src="/js/tether.js"></script>
         <script>
             new Tether({
                 element: '.element',

--- a/examples/viewport/index.html
+++ b/examples/viewport/index.html
@@ -37,8 +37,8 @@
       <p>Inspect the element to see how Tether decided
       to use <code>position: fixed</code>.</p>
     </div>
- 
-    <script src="/tether/tether.js"></script>
+
+    <script src="/js/tether.js"></script>
     <script>
       new Tether({
         element: '.element',


### PR DESCRIPTION
The examples are currently broken on the tether.io website, I assume this happened when you added the CNAME.

**Changes:**
- Updates resource urls to tether.js script inside examples ("[/tether/tether.js](http://tether.io/tether/tether.js)" &rarr; "[/js/tether.js](http://tether.io/js/tether.js)")
- My text editor trimmed some white-space on save
