### PR TITLE
Add "main" field to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "tether",
   "version": "0.5.2",
+  "main": "tether.js",
   "homepage": "https://github.hubspot.com/tether",
   "authors": [
     "Zack Bloom <zbloom@hubspot.com>",


### PR DESCRIPTION
This should fix the following message from `rails-assets-tether`:

```
This component doesn't define main assets in bower.json.
Please open new pull request in component's repository:
https://github.hubspot.com/tether
```
