### PR TITLE
#261: Import of Evented from Utils set instead of global scope

### DIFF
--- a/src/js/tether.js
+++ b/src/js/tether.js
@@ -14,6 +14,7 @@ const {
   updateClasses,
   defer,
   flush,
+  Evented,
   getScrollBarSize,
   removeUtilElements
 } = TetherBase.Utils;


### PR DESCRIPTION
When building library through webpack there're 2 global dependencies of tether.js on TetherBase and Evented, however Evented is part of TetherBase.Utils and we can import it from there.

Without fix import code looks like:
```javascript
global.TetherBase = require('exports-loader?TetherBase!./node_modules/tether/src/js/utils.js');
Object.assign(global, global.TetherBase.Utils);
global.Tether = require('exports-loader?Tether!./node_modules/tether/src/js/tether.js');
```

With fix
```javascript
global.TetherBase = require('exports-loader?TetherBase!./node_modules/tether/src/js/utils.js');
global.Tether = require('exports-loader?Tether!./node_modules/tether/src/js/tether.js');
```