### PR TITLE
If node.getBoundingClientRect is undefined return empty object

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -8,6 +8,9 @@ let zeroElement = null;
 // Same as native getBoundingClientRect, except it takes into account parent <frame> offsets
 // if the element lies within a nested document (<frame> or <iframe>-like).
 function getActualBoundingClientRect(node) {
+  if(typeof(node.getBoundingClientRect) !== 'function') {
+    return {};
+  }
   let boundingRect = node.getBoundingClientRect();
 
   // The original object returned by getBoundingClientRect is immutable, so we clone it


### PR DESCRIPTION
If node.getBoundingClientRect is undefined return empty object. IE bug fix.