### PR TITLE
workaround for uglifyjs _walk of null

### DIFF
--- a/src/js/tether.js
+++ b/src/js/tether.js
@@ -765,8 +765,9 @@ class TetherClass extends Evented {
         }
       } else {
         let offsetParentIsBody = true;
+        let d;
         function isFullscreenElement(e) {
-          let d = e.ownerDocument;
+          d = e.ownerDocument;
           let fe = d.fullscreenElement || d.webkitFullscreenElement || d.mozFullScreenElement || d.msFullscreenElement;
           return fe === e;
         }


### PR DESCRIPTION
As reported by #291 current version of tether causes uglifyjs to break. 

Although this is not an issue with tether directly, I believe there is value to have a workaround for people who rely on tether and uglifyjs in their build flows.