### PR TITLE
Move TetherBase and use imports

### DIFF
--- a/src/js/abutment.js
+++ b/src/js/abutment.js
@@ -1,9 +1,8 @@
-import TetherBase from './utils';
 import { updateClasses } from './utils/classes';
 import { defer } from './utils/deferred';
 import { getBounds } from './utils/bounds';
 
-TetherBase.modules.push({
+export default {
   position({ top, left }) {
     const { height, width } = this.cache('element-bounds', () => {
       return getBounds(this.element);
@@ -56,4 +55,4 @@ TetherBase.modules.push({
 
     return true;
   }
-});
+};

--- a/src/js/constraint.js
+++ b/src/js/constraint.js
@@ -1,4 +1,3 @@
-import TetherBase from './utils';
 import { updateClasses } from './utils/classes';
 import { defer } from './utils/deferred';
 import { extend } from './utils/general';
@@ -47,7 +46,7 @@ function getBoundingRect(tether, to) {
   return to;
 }
 
-TetherBase.modules.push({
+export default {
   position({ top, left, targetAttachment }) {
     if (!this.options.constraints) {
       return true;
@@ -360,4 +359,4 @@ TetherBase.modules.push({
 
     return { top, left };
   }
-});
+};

--- a/src/js/shift.js
+++ b/src/js/shift.js
@@ -1,6 +1,4 @@
-import TetherBase from './utils';
-
-TetherBase.modules.push({
+export default {
   position({ top, left }) {
     if (!this.options.shift) {
       return;
@@ -29,4 +27,4 @@ TetherBase.modules.push({
 
     return { top, left };
   }
-});
+};

--- a/src/js/tether.js
+++ b/src/js/tether.js
@@ -1,25 +1,19 @@
-/* globals TetherBase */
-
 import '../css/tether.scss';
 import '../css/tether-theme-arrows.scss';
 import '../css/tether-theme-arrows-dark.scss';
 import '../css/tether-theme-basic.scss';
+import Abutment from './abutment';
+import Constraint from './constraint';
+import Shift from './shift';
 import { Evented } from './evented';
-import TetherBase from './utils';
 import { addClass, removeClass, updateClasses } from './utils/classes';
 import { defer, flush } from './utils/deferred';
-import { extend } from './utils/general';
+import { extend, getScrollBarSize } from './utils/general';
 import { addOffset, attachmentToOffset, autoToFixedAttachment, offsetToPx, parseTopLeft } from './utils/offset';
 import { getBounds, removeUtilElements } from './utils/bounds';
-import './constraint';
-import './abutment';
-import './shift';
+import { getOffsetParent, getScrollParents } from './utils/parents';
 
-const {
-  getScrollParents,
-  getOffsetParent,
-  getScrollBarSize
-} = TetherBase.Utils;
+const TetherBase = { modules: [Constraint, Abutment, Shift] };
 
 function isFullscreenElement(e) {
   let d = e.ownerDocument;

--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -1,3 +1,5 @@
+let _scrollBarSize = null;
+
 export function extend(out = {}) {
   const args = [];
 
@@ -14,6 +16,46 @@ export function extend(out = {}) {
   });
 
   return out;
+}
+
+export function getScrollBarSize() {
+  if (_scrollBarSize) {
+    return _scrollBarSize;
+  }
+  const inner = document.createElement('div');
+  inner.style.width = '100%';
+  inner.style.height = '200px';
+
+  const outer = document.createElement('div');
+  extend(outer.style, {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    pointerEvents: 'none',
+    visibility: 'hidden',
+    width: '200px',
+    height: '150px',
+    overflow: 'hidden'
+  });
+
+  outer.appendChild(inner);
+
+  document.body.appendChild(outer);
+
+  const widthContained = inner.offsetWidth;
+  outer.style.overflow = 'scroll';
+  let widthScroll = inner.offsetWidth;
+
+  if (widthContained === widthScroll) {
+    widthScroll = outer.clientWidth;
+  }
+
+  document.body.removeChild(outer);
+
+  const width = widthContained - widthScroll;
+
+  _scrollBarSize = { width, height: width };
+  return _scrollBarSize;
 }
 
 export const uniqueId = (() => {

--- a/src/js/utils/parents.js
+++ b/src/js/utils/parents.js
@@ -1,11 +1,4 @@
-import { extend } from './utils/general';
-
-let TetherBase;
-if (typeof TetherBase === 'undefined') {
-  TetherBase = { modules: [] };
-}
-
-function getScrollParents(el) {
+export function getScrollParents(el) {
   // In firefox if the el is inside an iframe with display: none; window.getComputedStyle() will return null;
   // https://bugzilla.mozilla.org/show_bug.cgi?id=548397
   const computedStyle = getComputedStyle(el) || {};
@@ -48,56 +41,6 @@ function getScrollParents(el) {
   return parents;
 }
 
-function getOffsetParent(el) {
+export function getOffsetParent(el) {
   return el.offsetParent || document.documentElement;
 }
-
-let _scrollBarSize = null;
-
-function getScrollBarSize() {
-  if (_scrollBarSize) {
-    return _scrollBarSize;
-  }
-  const inner = document.createElement('div');
-  inner.style.width = '100%';
-  inner.style.height = '200px';
-
-  const outer = document.createElement('div');
-  extend(outer.style, {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    pointerEvents: 'none',
-    visibility: 'hidden',
-    width: '200px',
-    height: '150px',
-    overflow: 'hidden'
-  });
-
-  outer.appendChild(inner);
-
-  document.body.appendChild(outer);
-
-  const widthContained = inner.offsetWidth;
-  outer.style.overflow = 'scroll';
-  let widthScroll = inner.offsetWidth;
-
-  if (widthContained === widthScroll) {
-    widthScroll = outer.clientWidth;
-  }
-
-  document.body.removeChild(outer);
-
-  const width = widthContained - widthScroll;
-
-  _scrollBarSize = { width, height: width };
-  return _scrollBarSize;
-}
-
-TetherBase.Utils = {
-  getScrollParents,
-  getOffsetParent,
-  getScrollBarSize
-};
-
-export default TetherBase;


### PR DESCRIPTION
There was some weirdness leftover from when TetherBase was global. This moves all the utils that were added to TetherBase.modules to using actual exports and building the modules directly.