### PR TITLE
Ensure parent still exists when removing event listeners

### DIFF
--- a/src/js/tether.js
+++ b/src/js/tether.js
@@ -263,7 +263,9 @@ class TetherClass extends Evented {
 
     if (!isUndefined(this.scrollParents)) {
       this.scrollParents.forEach((parent) => {
-        parent.removeEventListener('scroll', this.position);
+        if (parent && parent.removeEventListener) {
+          parent.removeEventListener('scroll', this.position);
+        }
       });
     }
   }


### PR DESCRIPTION
When destroying tether, it assumes the parents still exist and are valid.  This can cause a race condition with frameworks like react, where if the component tether is hooked to is unmounted before tether can destroy, it will throw a 

```js
parent.removeEventListener is not a function
```

error.

