### PR TITLE
Fix "document is not defined" error

### DIFF
--- a/src/js/tether.js
+++ b/src/js/tether.js
@@ -47,7 +47,7 @@ function within(a, b, diff = 1) {
 }
 
 const transformKey = (() => {
-  if (isUndefined(document)) {
+  if (typeof document === "undefined") {
     return '';
   }
   const el = document.createElement('div');


### PR DESCRIPTION
Fixes #834

I see that this was updated on #333. But `isUndefined(document)` will throw an error if `document` wasn't set in the first place, while the `typeof` check will not.