### PR TITLE
Remove the markers when tether is destroyed

### DIFF
--- a/src/js/tether.js
+++ b/src/js/tether.js
@@ -275,6 +275,12 @@ class TetherClass extends Evented {
 
     this._removeClasses();
 
+    TetherBase.modules.forEach((module) => {
+      if (!isUndefined(module.destroy)) {
+        module.destroy.call(this);
+      }
+    });
+
     tethers.forEach((tether, i) => {
       if (tether === this) {
         tethers.splice(i, 1);
@@ -785,6 +791,13 @@ Tether.modules.push({
 
       this.markers[type] = { dot, el };
     });
+  },
+
+  destroy() {
+    ['target', 'element'].forEach((type => {
+      const el = this.markers[type].el;
+      this[type].removeChild(el);
+    }))
   },
 
   position({ manualOffset, manualTargetOffset }) {


### PR DESCRIPTION
As requested by #1051 a new pull request with the same fix.

For clarity the original description:

When a `tether` is created, a marker element is created and added both to the `element` and to the `target`.
This pull request removes the markers when the `tether` is destroyed.