### PR TITLE
Drop support for node < 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
       - run: yarn
       - run: yarn test
       

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "volta": {
-    "node": "^16.0.0",
+    "node": "16.0.0",
     "yarn": "1.22.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "volta": {
     "node": "16.0.0",
     "yarn": "1.22.10"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "volta": {
-    "node": "12.22.1",
+    "node": "^16.0.0",
     "yarn": "1.22.10"
   }
 }


### PR DESCRIPTION
### Problem:

Cypress cannot upgrade from version 9 to version 10 due to current node version 12 being end of life

### Solution:

Manually upgrade node version from 12 to >= 16

